### PR TITLE
port-mappings arg fix

### DIFF
--- a/autonomy_toolkit/dev.py
+++ b/autonomy_toolkit/dev.py
@@ -85,6 +85,7 @@ def _parse_ports(client, config, args):
                 ports = service.get("ports", [])
                 for i, port in enumerate(ports):
                     if 'published' in port:
+                        port['published'] = int(port['published'])
                         if port['published'] in mappings:
                             port['published'] = mappings[port['published']]
 


### PR DESCRIPTION
`docker compose config` outputs a port's "published" field as strings ([see here](https://github.com/compose-spec/compose-spec/blob/030884c92384a05312788b9b10dd6edd85105f91/spec.md?plain=1#L1568)). This causes issues when using ATK's `--port-mappings` argument as it assumes the published port is represented numerically. This change aims to fix this issue. 